### PR TITLE
[FEAT][#13] 'TODAY' 버튼 GUI 변경

### DIFF
--- a/diEAT/diEAT/Utils/CustomDatePicker.swift
+++ b/diEAT/diEAT/Utils/CustomDatePicker.swift
@@ -35,7 +35,7 @@ struct CustomDatePicker: View {
                 Button(action: {
                     showSidebar.toggle()
                 }) {
-                    Image(systemName: "text.justify")
+                    Image(systemName: "line.3.horizontal")
                         .font(.system(size: 20, weight: .heavy))
                         .frame(width: 44, height: 44)
                         .foregroundColor(Theme.textColor(scheme))
@@ -52,10 +52,10 @@ struct CustomDatePicker: View {
                     Text("TODAY")
                         .font(.system(size: 15, weight: .semibold, design: .monospaced))
                         .frame(height: 44)
-                        .padding(.horizontal, 5)
-                        .cornerRadius(30)
+                        .padding(.horizontal, 8)
+                        .background(.gray.opacity(0.5))
                         .foregroundColor(Theme.textColor(scheme))
-                        .border(Theme.defaultColor(scheme), width: 0.7)
+                        .cornerRadius(8)
                 }
             }
             .padding(.trailing, 22)
@@ -70,6 +70,7 @@ struct CustomDatePicker: View {
                     Text(extraDate()[1])
                         .font(.title.bold())
                 }
+                .padding(.top, 5)
                 
                 
                 Spacer(minLength: 0)
@@ -91,7 +92,7 @@ struct CustomDatePicker: View {
                 })
             }
             .padding(.horizontal, 10)
-            .padding(.bottom, 10)
+            .padding(.bottom, 8)
             
             // Day View
             HStack() {
@@ -140,12 +141,9 @@ struct CustomDatePicker: View {
     
     @ViewBuilder
     func CardView(value: DateValue) -> some View {
-        HStack {
-            if value.day != -1 {
-                Text("\(value.day)")
-                    .font(.system(size: 14, weight: .regular, design: .monospaced))
-                    .padding(10)
-            }
+        if value.day != -1 {
+            Text("\(value.day)")
+                .font(.system(size: 14, weight: .regular, design: .monospaced))
         }
     }
     


### PR DESCRIPTION
<img width="297" alt="스크린샷 2023-03-14 오후 10 14 36" src="https://user-images.githubusercontent.com/57654681/225013663-78e45ea5-c34b-4145-ad4f-777c3b0e944f.png">

+ 추가로 햄버거 버튼 아이콘: 네 줄(text.justify)에서 세 줄(line.3.horizontal)인 것으로 변경